### PR TITLE
Bessere externe Abhängigkeiten.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ target/
 
 # Individual settings
 localsettings.py
+
+# npm
+node_modules/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Take a look at the [Wiki](https://github.com/Strassengezwitscher/Strassengezwits
 ## How to setup
 ```bash
 pip install -r requirements.txt
+npm install
 cd strassengezwitscher
 python manage.py runserver
 ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "strassengezwitscher",
+  "version": "1.0.0",
+  "author": "strassengezwitscher",
+  "license": "SEE LICENSE IN 'LICENSE' file",
+  "homepage": "https://github.com/Strassengezwitscher/Strassengezwitscher#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Strassengezwitscher/Strassengezwitscher.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Strassengezwitscher/Strassengezwitscher/issues"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "bootstrap": "==3.3.6"
+  }
+}

--- a/strassengezwitscher/map/templates/index.html
+++ b/strassengezwitscher/map/templates/index.html
@@ -30,7 +30,7 @@
 {% block script_extension %}
 <script src="http://maps.googleapis.com/maps/api/js?sensor=false&extension=.js&output=embed"></script>
 <script type="text/javascript">
-    $(document).ready(function(){
+    (function() {
         google.maps.event.addDomListener(window, 'load', initialize);
         function initialize() {
             /* position Amsterdam */
@@ -51,6 +51,6 @@
             var map = new google.maps.Map(document.getElementById("map-canvas"), mapOptions);
             marker.setMap(map);
         };
-    });
+    })();
 </script>
 {% endblock %}

--- a/strassengezwitscher/strassengezwitscher/settings.py
+++ b/strassengezwitscher/strassengezwitscher/settings.py
@@ -106,6 +106,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
 STATIC_URL = '/static/'
+STATICFILES_DIRS = (os.path.join(BASE_DIR, "../node_modules"),)
 
 # Create a localsettings.py if you want to locally override settings
 # and don't want the changes to appear in 'git status'.

--- a/strassengezwitscher/templates/base.html
+++ b/strassengezwitscher/templates/base.html
@@ -1,12 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        {% load staticfiles %}
+
         <meta http-equiv="content-type" content="text/html; charset=UTF-8">
         <meta charset="utf-8">
         <title>Strassengezwitscher</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
-        <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+        <link href="{% static 'bootstrap/dist/css/bootstrap.min.css' %}" rel="stylesheet">
 
         <style type="text/css">
             html, body {

--- a/strassengezwitscher/templates/base.html
+++ b/strassengezwitscher/templates/base.html
@@ -39,9 +39,6 @@
         {% block content %}
         {% endblock %}
 
-        <script src="http://code.jquery.com/jquery-2.2.3.min.js" integrity="sha256-a23g1Nt4dtEYOj7bR+vTu7+T8VP13humZFBJNIYoEJo=" crossorigin="anonymous"></script>
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-
         {% block script_extension %}
         {% endblock %}
     </body>


### PR DESCRIPTION
Bessere Variante als #20.

> Fixt wohl auch #18.
> 
> Die Google Maps Js API muss wohl direkt vom Google Server geladen werden.

npm muss während des Deployments ausgeführt werden (@piepmatz)

Statische Dateien von Abhängigkeiten (wie JS und CSS) werden zur Zeit noch direkt im `node_modules` Verzeichnis referenziert. Das wird sich ändern, wir das Automatisierungstoll (#14) eingebaut haben. 