### PR TITLE
Configuration for tslint

### DIFF
--- a/frontend/contact.component.ts
+++ b/frontend/contact.component.ts
@@ -1,7 +1,7 @@
 import { Component } from "@angular/core";
 
 @Component({
-    selector: "contact-app",
-    templateUrl: "contact.component.html"
+    selector: "sg-contact",
+    templateUrl: "contact.component.html",
 })
 export class ContactComponent {}

--- a/frontend/main.ts
+++ b/frontend/main.ts
@@ -7,9 +7,8 @@ import { HTTP_PROVIDERS } from "@angular/http";
 import { StrassengezwitscherComponent } from "./sg.component";
 import { APP_ROUTER_PROVIDERS } from "./sg.routes";
 
-
 bootstrap(StrassengezwitscherComponent, [
     APP_ROUTER_PROVIDERS,
-    HTTP_PROVIDERS
+    HTTP_PROVIDERS,
 ])
 .catch(err => console.error(err));

--- a/frontend/main.ts
+++ b/frontend/main.ts
@@ -1,3 +1,4 @@
+// tslint:disable-next-line:no-reference
 /// <reference path="../typings/browser.d.ts" />
 
 import { bootstrap } from "@angular/platform-browser-dynamic";

--- a/frontend/map.component.ts
+++ b/frontend/map.component.ts
@@ -35,7 +35,7 @@ export class MapComponent implements AfterViewInit {
         this.mapService.getMapObjects()
                         .subscribe(
                             mapObjects => this.drawMapObjects(mapObjects),
-                            error => this.errorMessage = <any> error,
+                            error => this.errorMessage = <any> error
                         );
     }
 

--- a/frontend/map.component.ts
+++ b/frontend/map.component.ts
@@ -44,7 +44,7 @@ export class MapComponent implements AfterViewInit {
     }
 
     private drawMapObject(mapObject: MapObject) {
-        const latLng = new google.maps.LatLng(mapObject.location_lat, mapObject.location_long);
+        const latLng = new google.maps.LatLng(mapObject.locationLat, mapObject.locationLong);
         const infoWindow = new google.maps.InfoWindow({
             content: mapObject.name,
         });

--- a/frontend/map.component.ts
+++ b/frontend/map.component.ts
@@ -4,53 +4,53 @@ import { MapService } from "./map.service";
 import { MapObject } from "./mapObject";
 
 @Component({
-    selector: "map-app",
+    selector: "sg-map",
     templateUrl: "map.component.html",
-    providers: [MapService]
+    providers: [MapService],
 })
 export class MapComponent implements AfterViewInit {
-    errorMessage: string;
-    map: google.maps.Map;
-    currentlyOpenInfoWindow: google.maps.InfoWindow;
-    @ViewChild("mapCanvas") mapCanvas;
+    private errorMessage: string;
+    private map: google.maps.Map;
+    private currentlyOpenInfoWindow: google.maps.InfoWindow;
+    @ViewChild("mapCanvas") private mapCanvas;
 
     constructor(private mapService: MapService) {}
 
-    ngAfterViewInit() {
+    public ngAfterViewInit() {
         this.initMap();
         this.getMapObjects();
     }
 
-    initMap() {
+    private initMap() {
         const latlng = new google.maps.LatLng(52.3731, 4.8922);
         const mapOptions = {
             center: latlng,
             scrollWheel: false,
-            zoom: 13
+            zoom: 13,
         };
         this.map = new google.maps.Map(this.mapCanvas.nativeElement, mapOptions);
     }
 
-    getMapObjects() {
+    private getMapObjects() {
         this.mapService.getMapObjects()
                         .subscribe(
                             mapObjects => this.drawMapObjects(mapObjects),
-                            error => this.errorMessage = <any>error
+                            error => this.errorMessage = <any> error,
                         );
     }
 
-    drawMapObjects(mapObjects: MapObject[]) {
+    private drawMapObjects(mapObjects: MapObject[]) {
         mapObjects.map((mapObject) => this.drawMapObject(mapObject));
     }
 
-    drawMapObject(mapObject: MapObject) {
+    private drawMapObject(mapObject: MapObject) {
         const latLng = new google.maps.LatLng(mapObject.location_lat, mapObject.location_long);
         const infoWindow = new google.maps.InfoWindow({
-            content: mapObject.name
+            content: mapObject.name,
         });
         const marker = new google.maps.Marker({
             position: latLng,
-            title: mapObject.name
+            title: mapObject.name,
         });
 
         marker.addListener("click", (() => {
@@ -60,13 +60,13 @@ export class MapComponent implements AfterViewInit {
         marker.setMap(this.map);
     }
 
-    closeCurrentlyOpenInfoWindow() {
+    private closeCurrentlyOpenInfoWindow() {
         if (this.currentlyOpenInfoWindow) {
             this.currentlyOpenInfoWindow.close();
         }
     }
 
-    showInfoWindowForMarker(marker: google.maps.Marker, infoWindow: google.maps.InfoWindow) {
+    private showInfoWindowForMarker(marker: google.maps.Marker, infoWindow: google.maps.InfoWindow) {
         infoWindow.open(this.map, marker);
         this.currentlyOpenInfoWindow = infoWindow;
     }

--- a/frontend/map.service.ts
+++ b/frontend/map.service.ts
@@ -6,11 +6,11 @@ import { Observable } from "rxjs/Observable";
 
 @Injectable()
 export class MapService {
+    private const mapObjectsUrl = "api/mapobjects.json";
+
     constructor(private http: Http) {}
 
-    private mapObjectsUrl = "api/mapobjects.json";
-
-    getMapObjects(): Observable<MapObject[]> {
+    public getMapObjects(): Observable<MapObject[]> {
         return this.http.get(this.mapObjectsUrl)
                         .map(this.extractData)
                         .catch(this.handleError);
@@ -18,7 +18,7 @@ export class MapService {
 
     private extractData(response: Response) {
         let data = response.json() || [];
-        return <MapObject[]>data;
+        return <MapObject[]> data;
     }
 
     private handleError(error: any) {

--- a/frontend/map.service.ts
+++ b/frontend/map.service.ts
@@ -6,12 +6,12 @@ import { Observable } from "rxjs/Observable";
 
 @Injectable()
 export class MapService {
-    private const mapObjectsUrl = "api/mapobjects.json";
+    private static mapObjectsUrl = "api/mapobjects.json";
 
     constructor(private http: Http) {}
 
     public getMapObjects(): Observable<MapObject[]> {
-        return this.http.get(this.mapObjectsUrl)
+        return this.http.get(MapService.mapObjectsUrl)
                         .map(this.extractData)
                         .catch(this.handleError);
     }

--- a/frontend/mapObject.ts
+++ b/frontend/mapObject.ts
@@ -3,6 +3,6 @@ export class MapObject {
     public name: string;
     public active: boolean;
     public location: string;
-    public location_long: number;
-    public location_lat: number;
+    public locationLong: number;
+    public locationLat: number;
 }

--- a/frontend/mapObject.ts
+++ b/frontend/mapObject.ts
@@ -1,8 +1,8 @@
 export class MapObject {
-    id: number;
-    name: string;
-    active: boolean;
-    location: string;
-    location_long: number;
-    location_lat: number;
+    public id: number;
+    public name: string;
+    public active: boolean;
+    public location: string;
+    public location_long: number;
+    public location_lat: number;
 }

--- a/frontend/sg.component.ts
+++ b/frontend/sg.component.ts
@@ -4,12 +4,11 @@ import { ROUTER_DIRECTIVES } from "@angular/router";
 // Add the RxJS Observable operators we need in this app.
 import "./rxjs-operators";
 
-
 @Component({
     selector: "sg-app",
     templateUrl: "sg.component.html",
     directives: [
-        ROUTER_DIRECTIVES
-    ]
+        ROUTER_DIRECTIVES,
+    ],
 })
 export class StrassengezwitscherComponent {}

--- a/frontend/sg.routes.ts
+++ b/frontend/sg.routes.ts
@@ -3,12 +3,11 @@ import { provideRouter, RouterConfig } from "@angular/router";
 import { MapComponent } from "./map.component";
 import { ContactComponent } from "./contact.component";
 
-
 export const routes: RouterConfig = [
     { path: "", component: MapComponent },
-    { path: "contact", component: ContactComponent }
+    { path: "contact", component: ContactComponent },
 ];
 
 export const APP_ROUTER_PROVIDERS = [
-  provideRouter(routes)
+  provideRouter(routes),
 ];

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -153,7 +153,7 @@ if (!argv.production) {
 
     gulp.task('lint:typescript', function() {
         return gulp.src(ts_path)
-        .pipe(tslint())
+        .pipe(tslint({ configuration: "tslint.json" }))
         .pipe(tslint.report("prose", {
             emitError: false,
             summarizeFailureOutput: true

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "zone.js": "==0.6.12"
   },
   "devDependencies": {
+    "codelyzer": "0.0.24",
     "gulp-clean": "==0.3.2",
     "gulp-sass-lint": "==1.2.0",
     "gulp-tslint": "==5.0.0",

--- a/strassengezwitscher/mapobjects/serializers.py
+++ b/strassengezwitscher/mapobjects/serializers.py
@@ -3,6 +3,9 @@ from mapobjects.models import MapObject
 
 
 class MapObjectSerializer(serializers.ModelSerializer):
+    locationLong = serializers.DecimalField(source='location_long', max_digits=9, decimal_places=6)
+    locationLat = serializers.DecimalField(source='location_lat', max_digits=9, decimal_places=6)
+
     class Meta:
         model = MapObject
-        fields = ('id', 'name', 'active', 'location', 'location_long', 'location_lat')
+        fields = ('id', 'name', 'active', 'location', 'locationLong', 'locationLat')

--- a/strassengezwitscher/mapobjects/tests/test_views.py
+++ b/strassengezwitscher/mapobjects/tests/test_views.py
@@ -53,8 +53,8 @@ class MapObjectViewTests(APITestCase):
             u'active': True,
             u'name': u'Amsterdam1',
             u'location': u'Amsterdam',
-            u'location_long': u'4.894045',
-            u'location_lat': u'52.368829'
+            u'locationLong': u'4.894045',
+            u'locationLat': u'52.368829'
         }
         self.assertEqual(json.loads(response.content.decode("utf-8")), response_json)
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "tslint:recommended"
+}

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,8 @@
         "node_modules/codelyzer"
     ],
     "rules": {
+        "object-literal-sort-keys": false,
+
         "directive-selector-name": [true, "camelCase"],
         "component-selector-name": [true, "kebab-case"],
         "directive-selector-type": [true, "attribute"],

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,27 @@
 {
-    "extends": "tslint:recommended"
+    "extends": "tslint:recommended",
+    "rulesDirectory": [
+        "node_modules/codelyzer"
+    ],
+    "rules": {
+        "directive-selector-name": [true, "camelCase"],
+        "component-selector-name": [true, "kebab-case"],
+        "directive-selector-type": [true, "attribute"],
+        "component-selector-type": [true, "element"],
+        "directive-selector-prefix": [true, "sg"],
+        "component-selector-prefix": [true, "sg"],
+        "use-input-property-decorator": true,
+        "use-output-property-decorator": true,
+        "use-host-property-decorator": true,
+        "no-attribute-parameter-decorator": true,
+        "no-input-rename": true,
+        "no-output-rename": true,
+        "no-forward-ref" :true,
+        "use-life-cycle-interface": true,
+        "use-pipe-transform-interface": true,
+        "pipe-naming": [true, "camelCase", "sg"],
+        "component-class-suffix": true,
+        "directive-class-suffix": true,
+        "import-destructuring-spacing": true
+    }
 }


### PR DESCRIPTION
Squash.
Für Teile von #26.

Ich hab einen anderen Styleguide von [Tslint](https://github.com/palantir/tslint/blob/master/src/configs/recommended.ts), weil dieser besser gewartet wird als der [Airbnb](https://github.com/excelmicro/typescript) Styleguide. Der Tslint Styleguide wird mit Tslint aktualisiert. Sie sind sich sehr ähnlich, aber trotzdem gibt es ein paar [Regeln](https://github.com/palantir/tslint#core-rules), die wir klären müssen:
- Ich habe `object-literal-sort-keys` deaktiviert, weil das auch die `@Component`-Annotationen von Angular betreffen würde, die nicht alphabetisch sondern priorisiert geordnet werden sollten.
- Der Airbnb Styleguide wendet die `align`-Regel auch auf Funktionsargumente an. Wollen wir das auch?
- Der Airbnb Styleguide hat eine striktere Regeln für `member-ordering`. Wollen wir die übernehmen?

Außerdem hab ich einen Linter für Angular 2 gefunden. Der ist zwar nicht ganz vollständig (wip). Aber besser als nichts.