### PR TITLE
Update python dependencies and add tox support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,8 @@ node_modules/
 typings/**
 !typings/typings.d.ts
 
+# pyenv
+.python-version
+
 # Sensitive data
 strassengezwitscher/strassengezwitscher/initial/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-Django==1.9.5
-prospector==0.11.7
-djangorestframework==3.3.3
+-r requirements/prod.txt

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,0 +1,2 @@
+Django==1.9.5
+djangorestframework==3.3.3

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,2 +1,2 @@
-Django==1.9.5
+Django==1.9.7
 djangorestframework==3.3.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,2 +1,2 @@
 -r common.txt
-prospector==0.11.7
+prospector==0.12

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,2 +1,3 @@
 -r common.txt
 prospector==0.12
+tox==2.3.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,2 @@
+-r common.txt
+prospector==0.11.7

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,1 @@
+-r common.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27, py34, py35
+skipsdist = True
+
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}
+commands = python strassengezwitscher/manage.py test strassengezwitscher


### PR DESCRIPTION
Ich hab ein bisschen die Python-Abhängigkeiten aufgeräumt (und gleichzeitig geupdated), so dass wir die Abhängigkeiten für die Entwicklung nicht installieren müssen, wenn wir deployen.
Außerdem hab ich tox hinzugefügt, damit wir mit den unterschiedlichen Python-Version auch lokal testen können.
Zum Installieren von mehreren Python-Version hat mir dieser Link weitergeholfen: http://sqa.stackexchange.com/a/15257