### PR TITLE
Add url prefix for admin area.

### DIFF
--- a/strassengezwitscher/strassengezwitscher/settings/default.py
+++ b/strassengezwitscher/strassengezwitscher/settings/default.py
@@ -111,7 +111,7 @@ STATIC_URL = '/static/'
 ABSOLUTE_URL_OVERRIDES = {
     # Since we use auth.User to represent our users,
     # we have to provide an absolute URL for the User model.
-    'auth.user': lambda u: '/users/%s/' % u.id,
+    'auth.user': lambda u: '/intern/users/%s/' % u.id,
 }
 
 

--- a/strassengezwitscher/strassengezwitscher/urls.py
+++ b/strassengezwitscher/strassengezwitscher/urls.py
@@ -28,9 +28,9 @@ urlpatterns = [
     url(r'^api/', include('contact.urls')),
 
     # Admin area URLs
-    url(r'^facebook/', include('facebook.urls', namespace='facebook')),
-    url(r'^events/', include('events.urls', namespace='events')),
-    url(r'^users/', include('users.urls', namespace='users')),
+    url(r'^intern/facebook/', include('facebook.urls', namespace='facebook')),
+    url(r'^intern/events/', include('events.urls', namespace='events')),
+    url(r'^intern/users/', include('users.urls', namespace='users')),
 
     # User area URLs
     url(r'^$', views.index, name='index'),


### PR DESCRIPTION
Fixes #109

Ich hab darauf verzichtet die URL-Prefixe `intern` und `api` eine extra Variable anzulegen. Das würde die Lesbarkeit zu sehr beeinflussen. Die `urls.py` ist ja auch so gut strukturiert.