### PR TITLE
Data migration creates required groups.

### DIFF
--- a/strassengezwitscher/users/migrations/0001_initial.py
+++ b/strassengezwitscher/users/migrations/0001_initial.py
@@ -52,6 +52,9 @@ def reverse_func(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
+        ('auth', '0007_alter_validators_add_error_messages'),
+        ('events', '0001_initial'),
+        ('facebook', '0001_initial'),
     ]
 
     operations = [

--- a/strassengezwitscher/users/migrations/0001_initial.py
+++ b/strassengezwitscher/users/migrations/0001_initial.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from django.core.management.sql import emit_post_migrate_signal
+
+
+def forwards_func(apps, schema_editor):
+    """Creates the groups "Administratoren" and "Moderatoren" and sets their permissions."""
+    # We can't import the models directly as they may be newer versions than this migration expects.
+    # We use the historical versions instead.
+    User = apps.get_model('auth', 'User')
+    Group = apps.get_model('auth', 'Group')
+    Permission = apps.get_model('auth', 'Permission')
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    Event = apps.get_model('events', 'Event')
+    FacebookPage = apps.get_model('facebook', 'FacebookPage')
+
+    db_alias = schema_editor.connection.alias
+
+    # We rely on Permissions to exist. We do not create any, we just assign them to the Groups we create.
+    # However, Permissions are created at the end of migrations, too late for us if we start with an empty DB.
+    # We therefore emit the "post_migrate" signal. This results in permissions being already created when we need them.
+    # Further info: https://code.djangoproject.com/ticket/23422
+    # required args seem to change with nearly every Django release...
+    emit_post_migrate_signal(verbosity=0, interactive=False, db=db_alias)
+
+    admins = Group.objects.using(db_alias).create(name="Administratoren")
+    mods   = Group.objects.using(db_alias).create(name="Moderatoren")
+
+    # grant all privileges on the following models to mods and admins
+    for model in [Event, FacebookPage]:
+        content_type = ContentType.objects.get_for_model(model)
+        perms = Permission.objects.using(db_alias).filter(content_type=content_type)
+        mods.permissions.add(*perms)
+        admins.permissions.add(*perms)
+
+    # allow admins to add and change users (deletion is forbidden in favor of making users 'inactive')
+    user_content_type = ContentType.objects.get_for_model(User)
+    perms = Permission.objects.using(db_alias).filter(content_type=user_content_type).exclude(codename__contains='delete')
+    admins.permissions.add(*perms)
+
+
+def reverse_func(apps, schema_editor):
+    """Deletes the groups "Administratoren" and "Moderatoren."""
+    Group = apps.get_model('auth', 'Group')
+    db_alias = schema_editor.connection.alias
+    Group.objects.using(db_alias).filter(name="Administratoren").delete()
+    Group.objects.using(db_alias).filter(name="Moderatoren").delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, reverse_func),
+    ]


### PR DESCRIPTION
Fixes #102 

Anmerkungen:
- Damit Admins Nutzer auf inaktiv setzen können, reicht die normale change-Permission, das muss nicht extra hinzugefügt werden. Add-, change- und delete-Permissions werden von Django automatisch angelegt, dafür mussten wir nichts machen.
- Admins haben explizit keine Berechtigung, Nutzer zu löschen. Wir enforcen also Djangos Empfehlung, nur `is_active` zu benutzen.
- Permissions werden nicht automatisch gecheckt. Da wir fürs Bearbeiten des eigenes Profils eines Users wohl eine eigene View haben werden, die das Formular entsprechend füllt, brauchen wir dafür keine eigene Permission anzulegen. Das konfligiert **nicht** mit dem allgemeinen Verbot, als Moderator Änderungen an einem User vorzunehmen. 