### PR TITLE
API returns only active mapobjects

### DIFF
--- a/crowdgezwitscher/crowdgezwitscher/tests/test_api_views.py
+++ b/crowdgezwitscher/crowdgezwitscher/tests/test_api_views.py
@@ -1,4 +1,3 @@
-import json
 from decimal import Decimal
 
 from rest_framework import status

--- a/crowdgezwitscher/crowdgezwitscher/tests/test_api_views.py
+++ b/crowdgezwitscher/crowdgezwitscher/tests/test_api_views.py
@@ -11,7 +11,7 @@ class MapObjectApiViewTestTemplate(object):
         filtered_objects = json.loads(response.content.decode("utf-8"))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(filtered_objects), self.model.objects.count())
+        self.assertEqual(len(filtered_objects), 2)
 
     def test_partial_filter(self, url):
         response = self.client.get(url, {'min_lat': 10.0, 'min_long': 11.0})

--- a/crowdgezwitscher/crowdgezwitscher/tests/test_api_views.py
+++ b/crowdgezwitscher/crowdgezwitscher/tests/test_api_views.py
@@ -8,7 +8,7 @@ class MapObjectApiViewTestTemplate(object):
 
     def test_empty_filter(self, url):
         response = self.client.get(url)
-        filtered_objects = json.loads(response.content.decode("utf-8"))
+        filtered_objects = response.data
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(filtered_objects), 2)
@@ -34,7 +34,7 @@ class MapObjectApiViewTestTemplate(object):
     def test_correct_filter(self, url, rect_params):
 
         response = self.client.get(url, rect_params)
-        filtered_objects = json.loads(response.content.decode("utf-8"))
+        filtered_objects = response.data
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreater(len(filtered_objects), 0)

--- a/crowdgezwitscher/events/fixtures/events_views_testdata.json
+++ b/crowdgezwitscher/events/fixtures/events_views_testdata.json
@@ -23,10 +23,29 @@
     "pk": 2,
     "fields": {
         "name": "Test Event 2",
-        "active": false,
+        "active": true,
         "location": "There",
         "location_lat": "45.678000",
         "location_long": "87.654000",
+        "date": "2016-07-23",
+        "repetition_cycle": "unbekannter Rhythmus",
+        "organizer": "",
+        "type": "",
+        "url": "",
+        "counter_event": false,
+        "coverage": false,
+        "participants": ""
+    }
+},
+{
+    "model": "events.event",
+    "pk": 3,
+    "fields": {
+        "name": "Inactive Test Event",
+        "active": false,
+        "location": "Wow, much water",
+        "location_lat": "0.0",
+        "location_long": "0.0",
         "date": "2016-07-23",
         "repetition_cycle": "unbekannter Rhythmus",
         "organizer": "",

--- a/crowdgezwitscher/events/tests/test_api_views.py
+++ b/crowdgezwitscher/events/tests/test_api_views.py
@@ -45,7 +45,7 @@ class EventAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         events = json.loads(response.content.decode("utf-8"))
         self.assertTrue(all(event['active'] for event in events))
         self.assertEqual(len(events), 2)
-        self.assertTrue(len(events) < len(Event.object.count()))
+        self.assertTrue(len(events) < Event.objects.count())
 
     # GET /api/events/1/
     def test_read_detail_mapobject(self):

--- a/crowdgezwitscher/events/tests/test_api_views.py
+++ b/crowdgezwitscher/events/tests/test_api_views.py
@@ -42,7 +42,10 @@ class EventAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         url = reverse('events_api:list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(Event.objects.count(), 2)
+        events = json.loads(response.content.decode("utf-8"))
+        self.assertTrue(all(event['active'] for event in events))
+        self.assertEqual(len(events), 2)
+        self.assertTrue(len(events) < len(Event.object.count()))
 
     # GET /api/events/1/
     def test_read_detail_mapobject(self):

--- a/crowdgezwitscher/events/tests/test_api_views.py
+++ b/crowdgezwitscher/events/tests/test_api_views.py
@@ -69,6 +69,14 @@ class EventAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(json.loads(response.content.decode("utf-8"))['detail'], "Not found.")
 
+    # GET /api/events/3/
+    def test_read_detail_inactive_mapobject(self):
+        self.assertFalse(Event.objects.get(pk=3).active)
+        url = reverse('events_api:detail', kwargs={'pk': 3})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(json.loads(response.content.decode("utf-8"))['detail'], "Not found.")
+
     # PATCH /api/events/
     def test_modify_list_events(self):
         url = reverse('events_api:detail', kwargs={'pk': 1})

--- a/crowdgezwitscher/events/tests/test_api_views.py
+++ b/crowdgezwitscher/events/tests/test_api_views.py
@@ -62,6 +62,13 @@ class EventAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         }
         self.assertEqual(json.loads(response.content.decode("utf-8")), response_json)
 
+    # GET /api/events/1000/
+    def test_read_detail_not_existant_mapobject(self):
+        url = reverse('events_api:detail', kwargs={'pk': 1000})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(json.loads(response.content.decode("utf-8"))['detail'], "Not found.")
+
     # PATCH /api/events/
     def test_modify_list_events(self):
         url = reverse('events_api:detail', kwargs={'pk': 1})

--- a/crowdgezwitscher/events/tests/test_api_views.py
+++ b/crowdgezwitscher/events/tests/test_api_views.py
@@ -42,7 +42,7 @@ class EventAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         url = reverse('events_api:list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        events = json.loads(response.content.decode("utf-8"))
+        events = response.data
         self.assertTrue(all(event['active'] for event in events))
         self.assertEqual(len(events), 2)
         self.assertTrue(len(events) < Event.objects.count())
@@ -67,7 +67,6 @@ class EventAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         url = reverse('events_api:detail', kwargs={'pk': 1000})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(json.loads(response.content.decode("utf-8"))['detail'], "Not found.")
 
     # GET /api/events/3/
     def test_read_detail_inactive_mapobject(self):
@@ -75,7 +74,6 @@ class EventAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         url = reverse('events_api:detail', kwargs={'pk': 3})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(json.loads(response.content.decode("utf-8"))['detail'], "Not found.")
 
     # PATCH /api/events/
     def test_modify_list_events(self):

--- a/crowdgezwitscher/events/tests/test_views.py
+++ b/crowdgezwitscher/events/tests/test_views.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import User
 from django.urls import reverse
 from django.test import Client, TestCase
 

--- a/crowdgezwitscher/events/tests/test_views.py
+++ b/crowdgezwitscher/events/tests/test_views.py
@@ -60,7 +60,7 @@ class EventViewLoggedInTests(TestCase):
             'coverage': False,
         }
         response = self.client.post(reverse('events:create'), data, follow=True)
-        self.assertRedirects(response, reverse('events:detail', kwargs={'pk': 3}))
+        self.assertRedirects(response, reverse('events:detail', kwargs={'pk': 4}))
 
     def test_post_create_view_no_data(self):
         response = self.client.post(reverse('events:create'))

--- a/crowdgezwitscher/events/views.py
+++ b/crowdgezwitscher/events/views.py
@@ -55,11 +55,11 @@ class EventDelete(PermissionRequiredMixin, DeleteView):
 
 # API Views
 class EventAPIList(generics.ListAPIView):
-    queryset = Event.objects.all()
+    queryset = Event.objects.filter(active=True)
     serializer_class = EventSerializer
     filter_backends = (MapObjectFilter,)
 
 
 class EventAPIDetail(generics.RetrieveAPIView):
-    queryset = Event.objects.all()
+    queryset = Event.objects.filter(active=True)
     serializer_class = EventSerializer

--- a/crowdgezwitscher/facebook/fixtures/facebook_views_testdata.json
+++ b/crowdgezwitscher/facebook/fixtures/facebook_views_testdata.json
@@ -18,12 +18,26 @@
     "pk": 2,
     "fields": {
         "name": "Test page 2",
-        "active": false,
+        "active": true,
         "location": "Somewhere",
         "location_lat": "54.321000",
         "location_long": "12.345000",
         "notes": "",
         "facebook_id": "2",
+        "events": []
+    }
+},
+{
+    "model": "facebook.facebookpage",
+    "pk": 3,
+    "fields": {
+        "name": "Inactive test page",
+        "active": false,
+        "location": "Wow, much water",
+        "location_lat": "0.0",
+        "location_long": "0.0",
+        "notes": "",
+        "facebook_id": "3",
         "events": []
     }
 }

--- a/crowdgezwitscher/facebook/tests/test_api_views.py
+++ b/crowdgezwitscher/facebook/tests/test_api_views.py
@@ -45,7 +45,7 @@ class FacebookPageAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         facebook_pages = json.loads(response.content.decode("utf-8"))
         self.assertTrue(all(facebook_page['active'] for facebook_page in facebook_pages))
         self.assertEqual(len(facebook_pages), 2)
-        self.assertTrue(len(facebook_pages) < len(FacebookPage.object.count()))
+        self.assertTrue(len(facebook_pages) < FacebookPage.objects.count())
 
     # GET /api/facebook/1/
     def test_read_detail_mapobject(self):

--- a/crowdgezwitscher/facebook/tests/test_api_views.py
+++ b/crowdgezwitscher/facebook/tests/test_api_views.py
@@ -42,7 +42,10 @@ class FacebookPageAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         url = reverse('facebook_api:list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(FacebookPage.objects.count(), 2)
+        facebook_pages = json.loads(response.content.decode("utf-8"))
+        self.assertTrue(all(facebook_page['active'] for facebook_page in facebook_pages))
+        self.assertEqual(len(facebook_pages), 2)
+        self.assertTrue(len(facebook_pages) < len(FacebookPage.object.count()))
 
     # GET /api/facebook/1/
     def test_read_detail_mapobject(self):

--- a/crowdgezwitscher/facebook/tests/test_api_views.py
+++ b/crowdgezwitscher/facebook/tests/test_api_views.py
@@ -69,6 +69,14 @@ class FacebookPageAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(json.loads(response.content.decode("utf-8"))['detail'], "Not found.")
 
+    # GET /api/facebook/3/
+    def test_read_detail_inactive_mapobject(self):
+        self.assertFalse(FacebookPage.objects.get(pk=3).active)
+        url = reverse('facebook_api:detail', kwargs={'pk': 3})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(json.loads(response.content.decode("utf-8"))['detail'], "Not found.")
+
     # PATCH /api/facebook/
     def test_modify_list_facebook(self):
         url = reverse('facebook_api:detail', kwargs={'pk': 1})

--- a/crowdgezwitscher/facebook/tests/test_api_views.py
+++ b/crowdgezwitscher/facebook/tests/test_api_views.py
@@ -42,7 +42,7 @@ class FacebookPageAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         url = reverse('facebook_api:list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        facebook_pages = json.loads(response.content.decode("utf-8"))
+        facebook_pages = response.data
         self.assertTrue(all(facebook_page['active'] for facebook_page in facebook_pages))
         self.assertEqual(len(facebook_pages), 2)
         self.assertTrue(len(facebook_pages) < FacebookPage.objects.count())
@@ -67,7 +67,6 @@ class FacebookPageAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         url = reverse('facebook_api:detail', kwargs={'pk': 1000})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(json.loads(response.content.decode("utf-8"))['detail'], "Not found.")
 
     # GET /api/facebook/3/
     def test_read_detail_inactive_mapobject(self):
@@ -75,7 +74,6 @@ class FacebookPageAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         url = reverse('facebook_api:detail', kwargs={'pk': 3})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(json.loads(response.content.decode("utf-8"))['detail'], "Not found.")
 
     # PATCH /api/facebook/
     def test_modify_list_facebook(self):

--- a/crowdgezwitscher/facebook/tests/test_api_views.py
+++ b/crowdgezwitscher/facebook/tests/test_api_views.py
@@ -62,6 +62,13 @@ class FacebookPageAPIViewTests(APITestCase, MapObjectApiViewTestTemplate):
         }
         self.assertEqual(json.loads(response.content.decode("utf-8")), response_json)
 
+    # GET /api/facebook/1000/
+    def test_read_detail_not_existant_mapobject(self):
+        url = reverse('facebook_api:detail', kwargs={'pk': 1000})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(json.loads(response.content.decode("utf-8"))['detail'], "Not found.")
+
     # PATCH /api/facebook/
     def test_modify_list_facebook(self):
         url = reverse('facebook_api:detail', kwargs={'pk': 1})

--- a/crowdgezwitscher/facebook/tests/test_views.py
+++ b/crowdgezwitscher/facebook/tests/test_views.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import User
 from django.urls import reverse
 from django.test import Client, TestCase
 

--- a/crowdgezwitscher/facebook/tests/test_views.py
+++ b/crowdgezwitscher/facebook/tests/test_views.py
@@ -55,7 +55,7 @@ class FacebookPageViewLoggedInTests(TestCase):
             'facebook_id': '1234567890',
         }
         response = self.client.post(reverse('facebook:create'), data, follow=True)
-        self.assertRedirects(response, reverse('facebook:detail', kwargs={'pk': 3}))
+        self.assertRedirects(response, reverse('facebook:detail', kwargs={'pk': 4}))
 
     def test_post_create_view_no_data(self):
         response = self.client.post(reverse('facebook:create'))

--- a/crowdgezwitscher/facebook/views.py
+++ b/crowdgezwitscher/facebook/views.py
@@ -49,11 +49,11 @@ class FacebookPageDelete(PermissionRequiredMixin, DeleteView):
 
 # API Views
 class FacebookPageAPIList(generics.ListAPIView):
-    queryset = FacebookPage.objects.all()
+    queryset = FacebookPage.objects.filter(active=True)
     serializer_class = FacebookPageSerializer
     filter_backends = (MapObjectFilter,)
 
 
 class FacebookPageAPIDetail(generics.RetrieveAPIView):
-    queryset = FacebookPage.objects.all()
+    queryset = FacebookPage.objects.filter(active=True)
     serializer_class = FacebookPageSerializer


### PR DESCRIPTION
Fixes #166 

@mathebox: Du hast in #166 erwähnt, dass auch Frontend-Code refactored werden soll. Das hat sich mir jetzt nicht erschlossen. Woran hast du dabei gedacht?