### PR TITLE
Change icon colors for current events. Adjust mechanism how icons are dispatched.

### DIFF
--- a/frontend/app/helper.ts
+++ b/frontend/app/helper.ts
@@ -22,4 +22,11 @@ export class Helper {
     public static regionalDateFormat(date: Date) {
         return `${Helper.dayLeadingZero(date)}.${Helper.monthLeadingZero(date)}.${date.getFullYear()}`;
     }
+
+    public static dateIncremented(date: Date): Date {
+        let dateIncremented = new Date(date);
+        dateIncremented.setDate(dateIncremented.getDate() + 1);
+
+        return dateIncremented;
+    }
 }

--- a/frontend/app/helper.ts
+++ b/frontend/app/helper.ts
@@ -23,10 +23,10 @@ export class Helper {
         return `${Helper.dayLeadingZero(date)}.${Helper.monthLeadingZero(date)}.${date.getFullYear()}`;
     }
 
-    public static dateIncremented(date: Date): Date {
-        let dateIncremented = new Date(date);
-        dateIncremented.setDate(dateIncremented.getDate() + 1);
+    public static nextDay(date: Date): Date {
+        let nextDay = new Date(date);
+        nextDay.setDate(nextDay.getDate() + 1);
 
-        return dateIncremented;
+        return nextDay;
     }
 }

--- a/frontend/app/map/map.component.ts
+++ b/frontend/app/map/map.component.ts
@@ -151,7 +151,7 @@ export class MapComponent implements AfterViewInit {
         }
 
         const today = new Date();
-        if (today <= new Date(mapObject.date)) {
+        if (today < new Date(mapObject.date)) {
             return 1.0;
         } else {
             return 0.3;

--- a/frontend/app/map/map.component.ts
+++ b/frontend/app/map/map.component.ts
@@ -124,7 +124,7 @@ export class MapComponent implements AfterViewInit {
     }
 
     // TODO: should be part of the mapObject refactoring
-    private setMapObjectIconAndOpacity(mapObject: MapObject, mapObjectType: MapObjectType) {
+    private determineMapObjectAppearance(mapObject: MapObject, mapObjectType: MapObjectType) {
         if (mapObjectType === MapObjectType.FACEBOOK_PAGES) {
             this.setIconsAndOpacity(mapObject, "static/img/facebook.png",
                                         "static/img/facebook_aktiv.png", 1.0);
@@ -135,7 +135,7 @@ export class MapComponent implements AfterViewInit {
                                         "static/img/schild_aktiv_schwarz.png", 1.0);
             } else if (this.mapObjectSettings[mapObjectType].mapFilter.name === "aktuell") {
                 const today = new Date();
-                if (Helper.dateIncremented(mapObject.date) >= today) {
+                if (Helper.nextDay(mapObject.date) >= today) {
                     this.setIconsAndOpacity(mapObject, "static/img/schild_magenta.png",
                                         "static/img/schild_aktiv_magenta.png", 1.0);
                 } else {
@@ -148,7 +148,7 @@ export class MapComponent implements AfterViewInit {
 
     private drawMapObject(mapObject: MapObject, mapObjectType: MapObjectType) {
         const latLng = new google.maps.LatLng(mapObject.locationLat, mapObject.locationLong);
-        this.setMapObjectIconAndOpacity(mapObject, mapObjectType);
+        this.determineMapObjectAppearance(mapObject, mapObjectType);
         const marker = new google.maps.Marker({
             position: latLng,
             title: mapObject.name,

--- a/frontend/app/map/mapObject.model.ts
+++ b/frontend/app/map/mapObject.model.ts
@@ -4,6 +4,8 @@ export class MapObject {
     public locationLong: number;
     public locationLat: number;
     public date: Date;
+    public iconPath: string;
+    public iconSelectedPath: string;
 }
 
 export enum MapObjectType {

--- a/frontend/app/map/mapObject.model.ts
+++ b/frontend/app/map/mapObject.model.ts
@@ -6,6 +6,7 @@ export class MapObject {
     public date: Date;
     public iconPath: string;
     public iconSelectedPath: string;
+    public opacity: number;
 }
 
 export enum MapObjectType {


### PR DESCRIPTION
Fixes #290 

Habe keinen anderen einfachen Weg gesehen, da `opacity` und `icon` vom Typ, der Filteroption und dem Datum abhängen können. Nach dem Refactoring wird das sicher schöner. Unverständlich ist es momentan auch nicht.