### PR TITLE
Add validation for coverage configuration of events.

### DIFF
--- a/crowdgezwitscher/events/forms.py
+++ b/crowdgezwitscher/events/forms.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django import forms
 from extra_views import InlineFormSet
 
@@ -87,7 +88,7 @@ class EventForm(forms.ModelForm):
 
         # for activating a coverage all requried parameter must be set
         if coverage:
-            msg = 'Wird für eine Berichterstattung benötigt'
+            msg = u'Wird für eine Berichterstattung benötigt'
             errors = []
             if coverage_start is None:
                 errors.append(('coverage_start', msg))
@@ -98,7 +99,7 @@ class EventForm(forms.ModelForm):
             if errors:
                 for error in errors:
                     self.add_error(*error)
-                self.add_error('coverage', 'Nicht alle benötigen Felder wurden ausgefüllt')
+                self.add_error('coverage', u'Nicht alle benötigen Felder wurden ausgefüllt')
 
     def save(self, *args, **kwargs):
         instance = super(EventForm, self).save(*args, **kwargs)

--- a/crowdgezwitscher/events/forms.py
+++ b/crowdgezwitscher/events/forms.py
@@ -71,6 +71,35 @@ class EventForm(forms.ModelForm):
         if self.instance.pk:
             self.initial['facebook_pages'] = self.instance.facebook_pages.values_list('pk', flat=True)
 
+    def clean(self):
+        cleaned_data = super(EventForm, self).clean()
+        coverage = cleaned_data.get('coverage')
+        twitter_account_names = cleaned_data.get('twitter_account_names')
+        coverage_start = cleaned_data.get('coverage_start')
+        coverage_end = cleaned_data.get('coverage_end')
+
+        # coverage dates mus be in correct order
+        if coverage_start is not None and coverage_end is not None:
+            if coverage_end < coverage_start:
+                msg = "'coverage_start' muss vor 'coverage_end' liegen"
+                self.add_error('coverage_start', msg)
+                self.add_error('coverage_end', msg)
+
+        # for activating a coverage all requried parameter must be set
+        if coverage:
+            msg = 'Wird für eine Berichterstattung benötigt'
+            errors = []
+            if coverage_start is None:
+                errors.append(('coverage_start', msg))
+            if coverage_end is None:
+                errors.append(('coverage_end', msg))
+            if twitter_account_names is None or len(twitter_account_names) == 0:
+                errors.append(('twitter_account_names', msg))
+            if errors:
+                for error in errors:
+                    self.add_error(*error)
+                self.add_error('coverage', 'Nicht alle benötigen Felder wurden ausgefüllt')
+
     def save(self, *args, **kwargs):
         instance = super(EventForm, self).save(*args, **kwargs)
         if instance.pk:

--- a/crowdgezwitscher/events/forms.py
+++ b/crowdgezwitscher/events/forms.py
@@ -79,14 +79,14 @@ class EventForm(forms.ModelForm):
         coverage_start = cleaned_data.get('coverage_start')
         coverage_end = cleaned_data.get('coverage_end')
 
-        # coverage dates mus be in correct order
+        # coverage dates must be in correct order
         if coverage_start is not None and coverage_end is not None:
             if coverage_end < coverage_start:
                 msg = "'coverage_start' muss vor 'coverage_end' liegen"
                 self.add_error('coverage_start', msg)
                 self.add_error('coverage_end', msg)
 
-        # for activating a coverage all requried parameter must be set
+        # for activating a coverage all required parameters must be set
         if coverage:
             msg = u'Wird für eine Berichterstattung benötigt'
             errors = []

--- a/crowdgezwitscher/events/tests/test_views.py
+++ b/crowdgezwitscher/events/tests/test_views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import tempfile
 
@@ -229,10 +230,10 @@ class EventViewCorrectPermissionMixin(object):
         response = self.client.post(reverse('events:create'), post_data)
         self.assertEqual(response.status_code, 200)
         self.assertIn('form', response.context)  # shows form again
-        self.assertFormError(response, 'form', 'coverage', 'Nicht alle benötigen Felder wurden ausgefüllt')
-        self.assertFormError(response, 'form', 'twitter_account_names', 'Wird für eine Berichterstattung benötigt')
-        self.assertFormError(response, 'form', 'coverage_start', 'Wird für eine Berichterstattung benötigt')
-        self.assertFormError(response, 'form', 'coverage_end', 'Wird für eine Berichterstattung benötigt')
+        self.assertFormError(response, 'form', 'coverage', u'Nicht alle benötigen Felder wurden ausgefüllt')
+        self.assertFormError(response, 'form', 'twitter_account_names', u'Wird für eine Berichterstattung benötigt')
+        self.assertFormError(response, 'form', 'coverage_start', u'Wird für eine Berichterstattung benötigt')
+        self.assertFormError(response, 'form', 'coverage_end', u'Wird für eine Berichterstattung benötigt')
 
     def test_post_create_view_no_data(self):
         response = self.client.post(reverse('events:create'), self.empty_formset)

--- a/crowdgezwitscher/events/tests/test_views.py
+++ b/crowdgezwitscher/events/tests/test_views.py
@@ -147,6 +147,93 @@ class EventViewCorrectPermissionMixin(object):
         self.assertEqual(str(attachment2.attachment),
                          'event_attachments/%s_dolphindiary_xxxxx.txt2' % now().strftime("%Y/%m/%Y%m%d-%H%M"))
 
+    def test_post_create_view_coverage_valid_1(self):
+        post_data = self.post_data.copy()
+        post_data.update({
+            'coverage': True,
+            'twitter_account_names': 'Foobar',
+            'coverage_start': '2017-01-01',
+            'coverage_end': '2017-01-02',
+        })
+        response = self.client.post(reverse('events:create'), post_data, follow=True)
+        self.assertRedirects(response, reverse('events:detail', kwargs={'pk': 4}))
+
+    def test_post_create_view_coverage_valid_2(self):
+        post_data = self.post_data.copy()
+        post_data.update({
+            'coverage': False,
+            'coverage_start': '2017-01-01',
+            'coverage_end': '2017-01-02',
+        })
+        response = self.client.post(reverse('events:create'), post_data, follow=True)
+        self.assertRedirects(response, reverse('events:detail', kwargs={'pk': 4}))
+
+    def test_post_create_view_coverage_valid_3(self):
+        post_data = self.post_data.copy()
+        post_data.update({
+            'coverage': False,
+            'coverage_start': '2017-01-01',
+            'coverage_end': '2017-01-01',
+        })
+        response = self.client.post(reverse('events:create'), post_data, follow=True)
+        self.assertRedirects(response, reverse('events:detail', kwargs={'pk': 4}))
+
+    def test_post_create_view_coverage_valid_4(self):
+        post_data = self.post_data.copy()
+        post_data.update({
+            'coverage': False,
+            'coverage_start': '',
+            'coverage_end': '',
+        })
+        response = self.client.post(reverse('events:create'), post_data, follow=True)
+        self.assertRedirects(response, reverse('events:detail', kwargs={'pk': 4}))
+
+    def test_post_create_view_coverage_valid_5(self):
+        post_data = self.post_data.copy()
+        post_data.update({
+            'coverage': False,
+            'coverage_start': '2017-01-01',
+            'coverage_end': '',
+        })
+        response = self.client.post(reverse('events:create'), post_data, follow=True)
+        self.assertRedirects(response, reverse('events:detail', kwargs={'pk': 4}))
+
+    def test_post_create_view_coverage_missing_2(self):
+        post_data = self.post_data.copy()
+        post_data.update({
+            'coverage': False,
+            'coverage_start': '',
+            'coverage_end': '2017-01-02',
+        })
+        response = self.client.post(reverse('events:create'), post_data, follow=True)
+        self.assertRedirects(response, reverse('events:detail', kwargs={'pk': 4}))
+
+    def test_post_create_view_coverage_invalid_dates(self):
+        post_data = self.post_data.copy()
+        post_data.update({
+            'coverage': False,
+            'coverage_start': '2017-01-02',
+            'coverage_end': '2017-01-01',
+        })
+        response = self.client.post(reverse('events:create'), post_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('form', response.context)  # shows form again
+        self.assertFormError(response, 'form', 'coverage_start', "'coverage_start' muss vor 'coverage_end' liegen")
+        self.assertFormError(response, 'form', 'coverage_end', "'coverage_start' muss vor 'coverage_end' liegen")
+
+    def test_post_create_view_coverage_invalid_fields_missing(self):
+        post_data = self.post_data.copy()
+        post_data.update({
+            'coverage': True,
+        })
+        response = self.client.post(reverse('events:create'), post_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('form', response.context)  # shows form again
+        self.assertFormError(response, 'form', 'coverage', 'Nicht alle benötigen Felder wurden ausgefüllt')
+        self.assertFormError(response, 'form', 'twitter_account_names', 'Wird für eine Berichterstattung benötigt')
+        self.assertFormError(response, 'form', 'coverage_start', 'Wird für eine Berichterstattung benötigt')
+        self.assertFormError(response, 'form', 'coverage_end', 'Wird für eine Berichterstattung benötigt')
+
     def test_post_create_view_no_data(self):
         response = self.client.post(reverse('events:create'), self.empty_formset)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Fixes #297 

Die Validierung ist folgendermaßen:
- wenn es ein Start- und Enddatum für die Berichterstattung gibt, dann muss das Startdatum vor dem Enddatum liegen. Immer.
- wenn die Berichterstattung aktiviert ist, dürfen folgende Felder nicht leer sein:
  - Twitter-Accounts
  - Startdatum der Berichterstattung
  - Enddatum der Berichterstattung

Ich habe eine Validierung reaugelassen, die überprüft, ob das Datum der Veranstaltung im Berichterstattungszeitraum liegt. Es kann ja mal eine Ausnahme geben und dann ist's blöd.

@humuzz passt das so?