### PR TITLE
Show help text for form fields.

### DIFF
--- a/crowdgezwitscher/base/templates/templatetags/bootstrap-checkbox.html
+++ b/crowdgezwitscher/base/templates/templatetags/bootstrap-checkbox.html
@@ -9,4 +9,5 @@
         </label>
     </div>
 </div>
+{% bootstrap_help_text field.help_text %}
 {% bootstrap_error_list field.errors %}

--- a/crowdgezwitscher/base/templates/templatetags/bootstrap-field.html
+++ b/crowdgezwitscher/base/templates/templatetags/bootstrap-field.html
@@ -4,4 +4,5 @@
     {{ field.label_tag }}
     {{ field }}
 </div>
+{% bootstrap_help_text field.help_text %}
 {% bootstrap_error_list field.errors %}

--- a/crowdgezwitscher/base/templates/templatetags/bootstrap-helptext.html
+++ b/crowdgezwitscher/base/templates/templatetags/bootstrap-helptext.html
@@ -1,0 +1,5 @@
+{% if help_text %}
+<ul class="list-group">
+    <li class="list-group-item list-group-item-info">{{ help_text }}</li>
+</ul>
+{% endif %}

--- a/crowdgezwitscher/base/templatetags/bootstrap_tags.py
+++ b/crowdgezwitscher/base/templatetags/bootstrap_tags.py
@@ -10,6 +10,13 @@ def bootstrap_error_list(errors):
     }
 
 
+@register.inclusion_tag('templatetags/bootstrap-helptext.html')
+def bootstrap_help_text(help_text):
+    return {
+        'help_text': help_text,
+    }
+
+
 @register.inclusion_tag('templatetags/bootstrap-field.html')
 def bootstrap_field(field):
     return {


### PR DESCRIPTION
Die werden zwar gerade nur im Nutzerformular verwendet, sollten aber nicht untergehen.