### PR TITLE
Use deprecated travis image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: trusty
 sudo: required
+group: deprecated-2017Q4
 language: python
 python:
   - "3.5"


### PR DESCRIPTION
The latest Ubuntu Trusty image leads to failing e2e tests.
Until we fix this, we can cope with the deprecated image.