### PR TITLE
Increase tweet length to 560 chars.

### DIFF
--- a/crowdgezwitscher/twitter/models.py
+++ b/crowdgezwitscher/twitter/models.py
@@ -206,7 +206,7 @@ class Hashtag(models.Model):
 
 class Tweet(models.Model):
     tweet_id = UnsignedBigIntegerField(unique=True)
-    content = models.CharField(max_length=250)
+    content = models.CharField(max_length=560)
     account = models.ForeignKey(TwitterAccount, on_delete=models.CASCADE)
     hashtags = models.ManyToManyField(Hashtag)
     created_at = models.DateTimeField(default=datetime.now)


### PR DESCRIPTION
Even though the current limit is 280 chars, this change prepares us for
a hypothetical future length doubling.

Fixes #384 